### PR TITLE
Added example for using getImagesDpiInfo method

### DIFF
--- a/src/client/interfaces/template-editor.ts
+++ b/src/client/interfaces/template-editor.ts
@@ -1,6 +1,6 @@
 export interface IImageDpiInfo {
     /**
-     * Design atoms model 
+     * Design atoms model Item
      * https://customerscanvas.com/dev/editors/design-atoms-js/reference/design-atoms-model/item.html#_aurigma_design_atoms_model_Item_class
      */
     item: any;

--- a/src/client/interfaces/template-editor.ts
+++ b/src/client/interfaces/template-editor.ts
@@ -1,0 +1,9 @@
+export interface IImageDpiInfo {
+    /**
+     * Design atoms model 
+     * https://customerscanvas.com/dev/editors/design-atoms-js/reference/design-atoms-model/item.html#_aurigma_design_atoms_model_Item_class
+     */
+    item: any;
+    dpi: number;
+    qualityState: "None" | "Good" | "Warning" | "Bad";
+  }

--- a/src/client/samples/TemplateEditor.scss
+++ b/src/client/samples/TemplateEditor.scss
@@ -8,4 +8,7 @@
   &:hover {
     border: 1px solid transparent;
   }
+  &:disabled {
+    background: #e5e5e5;
+  }
 }

--- a/src/client/samples/TemplateEditor.tsx
+++ b/src/client/samples/TemplateEditor.tsx
@@ -2,13 +2,14 @@ import { useCallback, useEffect, useState } from "react";
 import { loadWorkflowElement } from "../shared/asset-loaders.js";
 import { ServerApiService } from "../shared/server-api-service.js";
 import { getWorkflowElementUrl, WorkflowElementType } from "../shared/urls.js";
-import axios from "axios";
 import "./TemplateEditor.scss";
 import Logo from "../components/logo/Logo.js";
+import { IImageDpiInfo } from "../interfaces/template-editor.js";
 
 const TemplateEditor = () => {
   const [isScriptLoaded, setIsScriptLoaded] = useState(false);
   const [editor, setEditor] = useState<any>(null);
+  const [saveIsDisabled, setSaveIsDisabled] = useState<boolean>(false);
   const userId = "testUserId42";
 
   useEffect(() => {
@@ -100,9 +101,17 @@ const TemplateEditor = () => {
             },
           },
         });
+
+        templateEditor?.addEventListener("change", () => {
+          const dpiInfo = templateEditor.getImagesDpiInfo();
+          const saveIsDisabled = !!dpiInfo.find(
+            (info: IImageDpiInfo) => info.qualityState === "Bad"
+          );
+          setSaveIsDisabled(saveIsDisabled);
+        });
       })();
     }
-  }, [isScriptLoaded]);
+  }, [isScriptLoaded, setSaveIsDisabled]);
 
   const initIntegrationData = (
     tenantId: number,
@@ -126,11 +135,12 @@ const TemplateEditor = () => {
   const saveDesign = useCallback(async () => {
     const serializedDesignModel = editor.getSerializedDesignModel();
     try {
-      // This code sets the destination design ID the same as the source 
-      // design ID. This way the design will be overwritten. 
-      // If you would like to create a copy instead of overwriting, 
+      // This code sets the destination design ID the same as the source
+      // design ID. This way the design will be overwritten.
+      // If you would like to create a copy instead of overwriting,
       // generate new GUID or another unique name.
-      const destinationDesignId = ServerApiService.getTemplateEditorPublicDesign();
+      const destinationDesignId =
+        ServerApiService.getTemplateEditorPublicDesign();
       await ServerApiService.savePublicDesign(
         destinationDesignId,
         serializedDesignModel
@@ -144,7 +154,11 @@ const TemplateEditor = () => {
   return (
     <au-template-editor>
       <div head-buttons="true">
-        <button className="save-button" onClick={saveDesign}>
+        <button
+          className="save-button"
+          disabled={saveIsDisabled}
+          onClick={saveDesign}
+        >
           Save
         </button>
       </div>


### PR DESCRIPTION
This sample update demonstrates how to use the `getImagesDpiInfo()` method, which retrieves DPI information for images used in the design. It also shows an example of disabling the design save button using this method and the `change` event.